### PR TITLE
Fix typo in app initialization.

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -12,7 +12,7 @@ def sparkconfig_builder():
         .set('spark.dynamicAllocation.executorIdleTimeout', 20) \
         .set('spark.dynamicAllocation.cachedExecutorIdleTimeout', 60)
 
-app = SparkCeleryApp(broker=BROKER_URL, backend=BACKEND_URL, sparkconfig_builder=sparkconfig_builder)
+app = SparkCeleryApp(broker=BROKER_URL, backend=BACKEND_URL, sparkconf_builder=sparkconfig_builder)
 
 
 # Setting priority for workers allows primary workers, with spillover if the primaries are busy. Used to minimize the


### PR DESCRIPTION
resolve #4 
Thanks for the awesome library Greg. I am not sure why this typo does not cause `TypeError:  got an unexpected keyword argument 'sparkconfig_builder'`. It caused the spark config to be silently overwritten by the default, which removed the cassandra host connections. This was a fun bug to track down.
